### PR TITLE
vtpm: flush the context for TPM created keys

### DIFF
--- a/kernel/src/vtpm/cmd/mod.rs
+++ b/kernel/src/vtpm/cmd/mod.rs
@@ -7,6 +7,7 @@
 pub mod tpm2_create_loaded;
 pub mod tpm2_create_primary;
 pub mod tpm2_evict_control;
+pub mod tpm2_flush_context;
 pub mod tpm2_get_capability;
 pub mod tpm2_nv_define_space;
 pub mod tpm2_nv_write;

--- a/kernel/src/vtpm/cmd/tpm2_flush_context.rs
+++ b/kernel/src/vtpm/cmd/tpm2_flush_context.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Jiaqi Gao <jiaqi.gao@intel.com>
+
+extern crate alloc;
+
+use super::*;
+use crate::vtpm::{vtpm_get_locked, MsTpmSimulatorInterface};
+use alloc::{vec, vec::Vec};
+
+const TPM2_CC_FLUSH_CONTEXT: u32 = 0x00000165;
+
+pub fn flush_context(handle: u32) -> Result<(), TpmCommandError> {
+    // Setup the flush context command
+    let command = tpm2_command_flush_context(handle)?;
+    let mut length = command.len();
+
+    // Copy the command into the request/response buffer
+    let mut buffer = vec![0u8; TPM_COMMAND_MAX_BUFFER_SIZE];
+    buffer[..length].copy_from_slice(&command);
+
+    // Execute the TPM command
+    vtpm_get_locked()
+        .send_tpm_command(&mut buffer, &mut length, 0)
+        .map_err(|_| TpmCommandError::Simulator)?;
+
+    // Validate and parse the TPM response
+    tpm2_response_flush_context(&buffer[..length])
+}
+
+fn tpm2_command_flush_context(handle: u32) -> Result<Vec<u8>, TpmCommandError> {
+    let mut command = Vec::new();
+
+    // TPM header
+    command.extend(&TPM_ST_NO_SESSIONS.to_be_bytes());
+    command.extend(&[0u8, 0u8, 0u8, 0u8]); // Placeholder for command size
+    command.extend(&TPM2_CC_FLUSH_CONTEXT.to_be_bytes());
+
+    // Object handle
+    command.extend(&handle.to_be_bytes());
+
+    // Update command size
+    let length = command.len() as u32;
+    command[2..6].copy_from_slice(&length.to_be_bytes());
+
+    Ok(command)
+}
+
+fn tpm2_response_flush_context(response: &[u8]) -> Result<(), TpmCommandError> {
+    if response.len() < TPM2_RESPONSE_HEADER_SIZE {
+        return Err(TpmCommandError::UnexpectedResponse);
+    }
+
+    // Safety: we have checked the length of the response
+    let rc = u32::from_be_bytes(response[6..10].try_into().unwrap());
+    if rc != TPM_RC_SUCCESS {
+        return Err(TpmCommandError::ResponseError(rc));
+    }
+
+    Ok(())
+}

--- a/kernel/src/vtpm/ecdsa.rs
+++ b/kernel/src/vtpm/ecdsa.rs
@@ -13,6 +13,7 @@ use super::{
 };
 use crate::tcg2::TPM2_HASH_ALG_ID_SHA384;
 use alloc::vec::Vec;
+use tpm2_flush_context::flush_context;
 use tpm2_sign::sign;
 
 const ECDSA_SHA384_SIGNATURE_SIZE: usize = 96;
@@ -32,6 +33,14 @@ impl EcdsaSigningKey {
         public_key.extend_from_slice(point_y);
 
         Self { handle, public_key }
+    }
+}
+
+impl Drop for EcdsaSigningKey {
+    fn drop(&mut self) {
+        if flush_context(self.handle).is_err() {
+            log::error!("Failed to flush context for TPM key");
+        }
     }
 }
 


### PR DESCRIPTION
Keys generated by TPM with `TPM2_CreateLoaded` command shall be released from TPM memory after they are used.

`TPM2_FlushContext` command is realized to remove the context of loaded object from TPM. For `EcdsaSigningKey`, the flush command is called when it is dropped.