### PR TITLE
libmstpm: add `-mno-red-zone` in CFLAGS

### DIFF
--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -103,7 +103,7 @@ $(LIBTPM): $(MSTPM_MAKEFILE) $(LIBCRYPTO)
 $(LIBPLATFORM): $(MSTPM_MAKEFILE) $(LIBCRYPTO)
 	$(MAKE) -C $(MSTPM_DIR) $(LIBPLATFORM_A)
 
-MSTPM_CFLAGS += -static -nostdinc -fno-stack-protector -fPIE -mno-sse
+MSTPM_CFLAGS += -static -nostdinc -fno-stack-protector -fPIE -mno-sse -mno-red-zone
 MSTPM_CFLAGS += -DSIMULATION=NO -DFILE_BACKED_NV=NO
 MSTPM_CFLAGS += -I$(LIBCRT_DIR)/include
 MSTPM_CFLAGS += -I$(OPENSSL_DIR)/include

--- a/libmstpm/deps/libcrt/Makefile
+++ b/libmstpm/deps/libcrt/Makefile
@@ -10,6 +10,7 @@ CFLAGS += -I./include -nostdinc -nostdlib
 CFLAGS += -m64 -march=x86-64 -mno-sse2 -fPIE
 CFLAGS += -fno-stack-protector
 CFLAGS += -ffreestanding
+CFLAGS += -mno-red-zone
 
 CC = gcc
 

--- a/libmstpm/deps/openssl_svsm.conf
+++ b/libmstpm/deps/openssl_svsm.conf
@@ -12,7 +12,7 @@ my %targets = (
         CFLAGS          => add(combine(picker(default => "-Wall",
                                           debug => "-g -O0",
                                           release => "-O3"),
-                                   "-fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector")),
+                                   "-fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector -mno-red-zone")),
         bn_ops          => "SIXTY_FOUR_BIT_LONG",
         lib_cppflags    => add("-DL_ENDIAN -DNO_SYSLOG -DOPENSSL_SMALL_FOOTPRINT -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE"),
         sys_id          => "SVSM"


### PR DESCRIPTION
From System V x86-64 abi, the 128-byte read zone area beyond the location pointed to by %rsp is considered to be reserved and shall not be modified by signal or interrupt handlers.

As the red area is enabled by default by gcc, the interrupt handler in the current implementation may disrupt the data within the area.

To avoid unpredictable behavior caused by this, disable the red zone by adding `-mno-red-zone` in CFLAGS for building openssl and ms-tpm-20-ref.