### PR TITLE
toolchain: Stick to the cargo version 1.76.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.76.0"
 targets = [ "x86_64-unknown-none" ]


### PR DESCRIPTION
Stick to a specific cargo version to avoid the new compiling errors and warnings introduced due to cargo updating.