### PR TITLE
kernel/tdx/ioreq: Audit GPA for tdvmcall MMIO request

### DIFF
--- a/kernel/src/tdx/ioreq.rs
+++ b/kernel/src/tdx/ioreq.rs
@@ -357,6 +357,13 @@ impl IoReq {
                 )?),
             ),
             IoType::TdvmcallMmio { addr, size } => {
+                // Check if the tdvmcall MMIO GPA is shared address or not.
+                // Suppose L2 only accesses shared MMIO GPA via tdvmcall.
+                // If it is not, probably indicates a bug in L2.
+                if !gpa_is_shared(addr) {
+                    return Err(TdxError::IoEmul(self.io_type));
+                }
+
                 let emul = TdvmcallIoEmul {
                     ctx: this_vcpu_mut(self.vm_id).get_ctx_mut(),
                     size: AddrSize::try_from(size)?,


### PR DESCRIPTION
Check GPA address before emulating a tdvmcall MMIO request. The L2 guest should only access shared MMIO GPA via tdvmcall, otherwise may indicate a bug in L2 guest.

Suggested-by: Reshetova Elena <elena.reshetova@intel.com>